### PR TITLE
Correccion de bug que impedia guardar Orden de Produccion

### DIFF
--- a/src/main/java/ar/edu/utn/sigmaproject/controller/ProductionFollowUpListController.java
+++ b/src/main/java/ar/edu/utn/sigmaproject/controller/ProductionFollowUpListController.java
@@ -61,6 +61,19 @@ public class ProductionFollowUpListController extends SelectorComposer<Component
 	}
 
 	private void refreshView() {
+		/*
+		//busca todas las ordenes de produccion en estado "Preparada" o "Iniciada"
+		ProductionOrderStateType productionOrderStateTypePreparada = productionOrderStateTypeRepository.findFirstByName("Preparada");
+		ProductionOrderStateType productionOrderStateTypeIniciada = productionOrderStateTypeRepository.findFirstByName("Iniciada");
+		productionOrderList = new ArrayList<ProductionOrder>();
+		for(ProductionOrder each : productionOrderRepository.findAll()) {
+			String currentStateTypeName = each.getCurrentStateType().getName();
+			if(currentStateTypeName.equalsIgnoreCase(productionOrderStateTypePreparada.getName()) || currentStateTypeName.equalsIgnoreCase(productionOrderStateTypeIniciada.getName())) {
+
+			}
+		}
+		 */
+
 		// busca todos los planes de produccion que esten en estado "Lanzado" o "En Produccion", y 
 		// guarda todas sus ordenes de produccion en la lista
 		ProductionPlanStateType productionPlanStateTypeLanzado = productionPlanStateTypeRepository.findFirstByName("Lanzado");
@@ -77,7 +90,7 @@ public class ProductionFollowUpListController extends SelectorComposer<Component
 		productionOrderListModel = new ListModelList<ProductionOrder>(productionOrderList);
 		productionOrderGrid.setModel(productionOrderListModel);
 	}
-	
+
 	@Listen("onEditProductionOrder = #productionOrderGrid")
 	public void doEditProductionOrder(ForwardEvent evt) {
 		ProductionOrder productionOrder = (ProductionOrder) evt.getData();
@@ -85,7 +98,7 @@ public class ProductionFollowUpListController extends SelectorComposer<Component
 		Include include = (Include) Selectors.iterable(evt.getPage(), "#mainInclude").iterator().next();
 		include.setSrc("/production_follow_up.zul");
 	}
-	
+
 	public String getPercentComplete(ProductionOrder aux) {
 		if(aux != null) {
 			List<ProductionOrderDetail> productionOrderDetailList = aux.getDetails();

--- a/src/main/webapp/production_order_creation.zul
+++ b/src/main/webapp/production_order_creation.zul
@@ -61,6 +61,12 @@
 					<button id="generateDetailsButton" label="Actualizar Detalles"/>
 				</hbox>
         		<grid id="processTypeGrid" sizedByContent="true" span="true">
+        			<auxhead>
+						<auxheader colspan="2"/>
+					    <auxheader colspan="2" align="center">
+					        <button id="autoAssignButton" label="Asignar Empleados y Maquinas Automaticamente"/>
+					    </auxheader>
+					</auxhead>
         			<columns>
 			            <column label="Proceso" align="left"/>
 			            <column label="Tipo de Maquina" align="center"/>


### PR DESCRIPTION
- agregado boton de asignar automaticamente maquinas y empleados a orden.
- eliminado variables innecesarias.
- reducida cantidad de consultas a BD en guardado de orden.
- bug de sql corregido eliminando el ordenamiento de la lista de detalles de produccion. Hay que buscar una alternativa para que se ordene la lista por secuencia en la pantalla.